### PR TITLE
ENH: Provide long description for PyPI package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ maintainer = Mathias Goncalves
 maintainer_email = mathiasg@mit.edu
 description = Etelemetry python client API
 license = Apache License, 2.0
+long_description = file:README.md
+long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
 provides =
     etelemetry
 classifiers =


### PR DESCRIPTION
Just plops the README in there, and marks it as Github-flavored markdown (GFM).