### PR TITLE
enh: flag ci requests

### DIFF
--- a/etelemetry/client.py
+++ b/etelemetry/client.py
@@ -1,13 +1,22 @@
 from requests import request, ConnectionError, ReadTimeout
 import os
+
+import ci
+
 from .config import ET_PROJECTS
 
 
 def _etrequest(endpoint, method="get", **kwargs):
     if kwargs.get('timeout') is None:
         kwargs['timeout'] = 5
+
+    params = {}
+    if ci.is_ci():
+        # send along CI information
+        params = ci.info()
+
     try:
-        res = request(method, endpoint, **kwargs)
+        res = request(method, endpoint, params=params, **kwargs)
     except ConnectionError:
         raise RuntimeError("Connection to server could not be made")
     except ReadTimeout:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
 python_requires = >= 2.7
 install_requires =
     requests
+    ci-info
 test_requires =
     pytest >= 4.4.0
     pytest-cov


### PR DESCRIPTION
Adds detection of _most_ CI environments, and adds some basic information to the server ping.

`ci.info()` is a _dict_ composed of `name`, `is_ci` and `is_pr` fields.