### PR TITLE
MAINT: Reflect ci-info import change

### DIFF
--- a/etelemetry/client.py
+++ b/etelemetry/client.py
@@ -1,7 +1,14 @@
 from requests import request, ConnectionError, ReadTimeout
 import os
 
-import ci
+try:
+    import ci_info
+except ImportError:
+    import warnings
+    warnings.warn(
+        "Deprecated version of ci-info found, upgrade to remove this warning", DeprecationWarning
+    )
+    import ci as ci_info
 
 from .config import ET_PROJECTS
 
@@ -13,9 +20,9 @@ def _etrequest(endpoint, method="get", **kwargs):
         kwargs['timeout'] = 5
 
     params = {}
-    if ci.is_ci():
+    if ci_info.is_ci():
         # send along CI information
-        params = ci.info()
+        params = ci_info.info()
 
     try:
         res = request(method, endpoint, params=params, **kwargs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 python_requires = >= 3.5
 install_requires =
     requests
-    ci-info
+    ci-info >= 0.2
 test_requires =
     pytest >= 4.4.0
     pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,9 @@ tests =
 all =
     %(test)s
 
+[flake8]
+max-line-length = 99
+
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
Reflects import change made in https://github.com/mgxd/ci-info/commit/ee4eb1a9b6d92885d547128c6972e70e5dcee2ed. Temporarily avoids blowing up with previous installations of `ci-info`, but we should probably remove this check down the line.

also expands linter-tolerable line length