### PR TITLE
Remove encoding parameter from res.json for python 3.9 compatibility

### DIFF
--- a/etelemetry/client.py
+++ b/etelemetry/client.py
@@ -64,7 +64,7 @@ def get_project(repo, **rargs):
     if "/" not in repo:
         raise ValueError("Invalid repository")
     res = _etrequest(ET_PROJECTS.format(repo=repo), **rargs)
-    return res.json(encoding="utf-8")
+    return res.json()
 
 
 def check_available_version(project, version, lgr=None, raise_exception=False):


### PR DESCRIPTION
Currently tests fail for python 3.9 with:

```
=================================== FAILURES ===================================
_______________________________ test_get_project _______________________________

    def test_get_project():
        repo = "invalidrepo"
        with pytest.raises(ValueError):
            get_project(repo)
        repo = "github/hub"
>       res = get_project(repo)

test_client.py:24:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../client.py:59: in get_project
    return res.json(encoding="utf-8")
/usr/lib/python3/dist-packages/requests/models.py:889: in json
    return complexjson.loads(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

s = '{"version":"2.14.2"}', cls = <class 'json.decoder.JSONDecoder'>
object_hook = None, parse_float = None, parse_int = None, parse_constant = None
object_pairs_hook = None, kw = {'encoding': 'utf-8'}

    def loads(s, *, cls=None, object_hook=None, parse_float=None,
            parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
        """Deserialize ``s`` (a ``str``, ``bytes`` or ``bytearray`` instance
        containing a JSON document) to a Python object.

        ``object_hook`` is an optional function that will be called with the
        result of any object literal decode (a ``dict``). The return value of
        ``object_hook`` will be used instead of the ``dict``. This feature
        can be used to implement custom decoders (e.g. JSON-RPC class hinting).

        ``object_pairs_hook`` is an optional function that will be called with the
        result of any object literal decoded with an ordered list of pairs.  The
        return value of ``object_pairs_hook`` will be used instead of the ``dict``.
        This feature can be used to implement custom decoders.  If ``object_hook``
        is also defined, the ``object_pairs_hook`` takes priority.

        ``parse_float``, if specified, will be called with the string
        of every JSON float to be decoded. By default this is equivalent to
        float(num_str). This can be used to use another datatype or parser
        for JSON floats (e.g. decimal.Decimal).

        ``parse_int``, if specified, will be called with the string
        of every JSON int to be decoded. By default this is equivalent to
        int(num_str). This can be used to use another datatype or parser
        for JSON integers (e.g. float).

        ``parse_constant``, if specified, will be called with one of the
        following strings: -Infinity, Infinity, NaN.
        This can be used to raise an exception if invalid JSON numbers
        are encountered.

        To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
        kwarg; otherwise ``JSONDecoder`` is used.
        """
        if isinstance(s, str):
            if s.startswith('\ufeff'):
                raise JSONDecodeError("Unexpected UTF-8 BOM (decode using
utf-8-sig)",
                                      s, 0)
        else:
            if not isinstance(s, (bytes, bytearray)):
                raise TypeError(f'the JSON object must be str, bytes or bytearray, '
                                f'not {s.__class__.__name__}')
            s = s.decode(detect_encoding(s), 'surrogatepass')

        if (cls is None and object_hook is None and
                parse_int is None and parse_float is None and
                parse_constant is None and object_pairs_hook is None and not kw):
            return _default_decoder.decode(s)
        if cls is None:
            cls = JSONDecoder
        if object_hook is not None:
            kw['object_hook'] = object_hook
        if object_pairs_hook is not None:
            kw['object_pairs_hook'] = object_pairs_hook
        if parse_float is not None:
            kw['parse_float'] = parse_float
        if parse_int is not None:
            kw['parse_int'] = parse_int
        if parse_constant is not None:
            kw['parse_constant'] = parse_constant
>       return cls(**kw).decode(s)
E       TypeError: __init__() got an unexpected keyword argument 'encoding'

/usr/lib/python3.9/json/__init__.py:359: TypeError
_____________________________ test_check_available _____________________________

    def test_check_available():
        repo = "invalidrepo"
        res = check_available_version(repo, "0.1.0")
        assert res is None
        repo = "github/hub"
        res = check_available_version(repo, "0.1.0")
>       assert "version" in res
E       TypeError: argument of type 'NoneType' is not iterable

test_client.py:49: TypeError
====================== 2 failed, 2 passed in 1.42 seconds ======================

```

This is an attempt to fix it.