### PR TITLE
RF/OPT: delay import of requests until used/needed in _etrequest

### DIFF
--- a/etelemetry/client.py
+++ b/etelemetry/client.py
@@ -1,4 +1,3 @@
-from requests import request, ConnectionError, ReadTimeout
 import os
 
 try:
@@ -21,6 +20,9 @@ class BadVersionError(RuntimeError):
 
 
 def _etrequest(endpoint, method="get", **kwargs):
+    # Delay requests import until actually used to at least not
+    # add runtime penalty of requests import whenever not needed
+    from requests import request, ConnectionError, ReadTimeout
     if kwargs.get('timeout') is None:
         kwargs['timeout'] = 5
 


### PR DESCRIPTION
It is a partial workaround for
https://github.com/sensein/etelemetry-client/issues/29
where ultimately requests is not a dependency at all, but rather built-in http
is used for that minimal amount of interaction needed.

This minimal change should shave off about 60ms from etelemetry import/use
runtime whenever no refresh _etrequest is needed to be sent