### PR TITLE
Expose BadVersionError exception at top level API

### DIFF
--- a/etelemetry/__init__.py
+++ b/etelemetry/__init__.py
@@ -1,1 +1,1 @@
-from .client import get_project, check_available_version
+from .client import get_project, check_available_version, BadVersionError


### PR DESCRIPTION
Since it could be raised by check_available_version and thus
makes sense to have it imported along