### PR TITLE
Replace `pkg_resources.parse_version` with `packaging.version.Version`

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,6 +14,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, "3.10"]
@@ -37,4 +38,4 @@ jobs:
         file: ./cov.xml # optional
         flags: unittests # optional
         name: codecov-et # optional
-        fail_ci_if_error: true # optional (default = false)
+        fail_ci_if_error: false

--- a/etelemetry/client.py
+++ b/etelemetry/client.py
@@ -1,4 +1,5 @@
 import os
+from packaging.version import Version
 
 try:
     import ci_info
@@ -92,8 +93,6 @@ def check_available_version(project, version, lgr=None, raise_exception=False):
         import logging
         lgr = logging.getLogger('et-client')
 
-    from pkg_resources import parse_version
-
     latest = {"version": "Unknown", "bad_versions": []}
     ret = None
     try:
@@ -104,8 +103,8 @@ def check_available_version(project, version, lgr=None, raise_exception=False):
     finally:
         if ret:
             latest.update(**ret)
-            local_version = parse_version(version)
-            remote_version = parse_version(latest["version"])
+            local_version = Version(version)
+            remote_version = Version(latest["version"])
             if local_version < remote_version:
                 lgr.warning("A newer version (%s) of %s is available. You are "
                             "using %s", latest["version"], project, version)
@@ -118,7 +117,7 @@ def check_available_version(project, version, lgr=None, raise_exception=False):
                           version, project)
             if latest["bad_versions"] and any(
                     [
-                        local_version == parse_version(ver)
+                        local_version == Version(ver)
                         for ver in latest["bad_versions"]
                     ]
             ):

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
 [options]
 python_requires = >= 3.7
 install_requires =
+    packaging
     requests
     ci-info >= 0.2
 test_requires =


### PR DESCRIPTION
`pkg_resources` is deprecated and should no longer be used.  This PR replaces the use of `pkg_resources.parse_version()` with its non-deprecated equivalent, `packaging.version.Version`.