### PR TITLE
CI: Build with build

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-python@v4
     - name: Build and check package
       run: |

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -14,18 +14,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
+    - uses: actions/setup-python@v4
+    - name: Build
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
+        pipx run build
+        pipx run twine check dist/*
+    - name: Upload to PyPI
+      run: pipx run twine upload dist/*
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py bdist_wheel
-        twine upload dist/*

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -4,6 +4,10 @@
 name: Upload Python Package
 
 on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
   release:
     types: [created]
 
@@ -15,12 +19,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
-    - name: Build
+    - name: Build and check package
       run: |
         pipx run build
         pipx run twine check dist/*
     - name: Upload to PyPI
       run: pipx run twine upload dist/*
+      if: ${{ github.event_name == 'release' }}
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Calling `python setup.py` directly is deprecated. Using a dedicated build tool like `build` is the thing now. Also switched to pipx to bypass the install step; pipx will ensure the tools we directly use get installed and build will ensure the build-time dependencies get installed.